### PR TITLE
WIP: Use cligen for parsing arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nimcache/
+/nistow

--- a/nistow.nimble
+++ b/nistow.nimble
@@ -8,4 +8,4 @@ srcDir        = "src"
 bin = @["nistow"]
 # Dependencies
 
-requires "nim >= 0.18.0"
+requires "nim >= 0.18.0", "cligen >= 0.9.11"

--- a/src/nistow.nim
+++ b/src/nistow.nim
@@ -3,9 +3,9 @@
 # Stow alternative in nim to manage dotfiles.
 
 
-import os, strutils, strformat, parseopt2
+import os, strutils, strformat
 type
-  LinkInfo = tuple[original:string, dest:string] 
+  LinkInfo = tuple[original:string, dest:string]
 
 proc getLinkableFiles*(appPath: string, dest: string=expandTilde("~")): seq[LinkInfo] =
 
@@ -31,7 +31,7 @@ proc getLinkableFiles*(appPath: string, dest: string=expandTilde("~")): seq[Link
     linkables.add(linkInfo)
   return linkables
 
-proc stow(linkables: seq[LinkInfo], simulate: bool=true, verbose: bool=true, force: bool=false) = 
+proc stow(linkables: seq[LinkInfo], simulate: bool=true, verbose: bool=true, force: bool=false) =
     # Creates symoblic links and related directories
 
     # linkables is a list of tuples (filepath, linkpath) : List[Tuple[file_path, link_path]]
@@ -55,63 +55,37 @@ proc stow(linkables: seq[LinkInfo], simulate: bool=true, verbose: bool=true, for
           if verbose:
             echo(fmt("Skipping linking {filepath} -> {linkpath}"))
 
-
-proc writeHelp() = 
-    echo """
-Stow 0.1.0 (Manage your dotfiles easily)
-
-Allowed arguments:
-    -h | --help     : show help
-    -v | --version  : show version
-    --verbose       : verbose messages
-    -s | --simulate : simulate stow operation
-    -f | --force    : override old links
-    -a | --app      : application path to stow
-    -d | --dest     : destination to stow to
-
-    """
 proc writeVersion() =
     echo "Stow version 0.1.0"
 
+proc nistow*(version=false, simulate=false, verbose=false, force=false, app: string, dest="") =
+  ##Stow 0.1.0 (Manage your dotfiles easily)
 
-proc cli*() =
-  var 
-    simulate, verbose, force: bool = false
-    app, dest: string = ""
-  
-  if paramCount() == 0:
-    writeHelp()
-    quit(0)
-  
-  for kind, key, val in getopt():
-    case kind
-    of cmdLongOption, cmdShortOption:
-        case key
-        of "help", "h": 
-            writeHelp()
-            quit()
-        of "version", "v":
-            writeVersion()
-            quit()
-        of "simulate", "s": simulate = true
-        of "verbose": verbose = true
-        of "force", "f": force = true
-        of "app", "a": app = val
-        of "dest", "d": dest = val 
-        else:
-          discard
-    else:
-      discard 
+  var dest_local: string
+
+  if version:
+    writeVersion()
+    quit()
 
   if dest.isNilOrEmpty():
-    dest = getHomeDir()
-  if app.isNilOrEmpty():
-    echo "Make sure to provide --app flags"
-    quit(1)
+    dest_local = getHomeDir()
+  else:
+    dest_local = dest
+
   try:
-    stow(getLinkableFiles(appPath=app, dest=dest), simulate=simulate, verbose=verbose, force=force)
+    stow(getLinkableFiles(appPath=app, dest=dest_local), simulate=simulate, verbose=verbose, force=force)
   except ValueError:
     echo "Error happened: " & getCurrentExceptionMsg()
 
 when isMainModule:
-  cli()
+  import cligen
+  # Use dispatchGen to do some initial setup for cligen, but don't run nistow, yet..
+  # The mandatoryOverride option allows the absence of any mandatory switch
+  # (like --app in this case), if the mandatoryOverride switch --version is present.
+  dispatchGen(nistow,
+              mandatoryOverride = @["version"])
+  # If the user has run the binary without any switches, pass the --help switch
+  # automatically to dispatch_nistow.
+  # Else, collect the passed switches using commandLineParams() and pass those to
+  # dispatch_nistow.
+  quit(dispatch_nistow(if paramCount() > 0: commandLineParams() else: @[ "--help" ]))

--- a/src/nistow.nim
+++ b/src/nistow.nim
@@ -58,22 +58,16 @@ proc stow(linkables: seq[LinkInfo], simulate: bool=true, verbose: bool=true, for
 proc writeVersion() =
     echo "Stow version 0.1.0"
 
-proc nistow*(version=false, simulate=false, verbose=false, force=false, app: string, dest="") =
+proc nistow*(version: bool=false, simulate: bool=false, verbose: bool=false, force: bool=false,
+             app: string, dest :string=getHomeDir()) =
   ##Stow 0.1.0 (Manage your dotfiles easily)
-
-  var dest_local: string
 
   if version:
     writeVersion()
     quit()
 
-  if dest.isNilOrEmpty():
-    dest_local = getHomeDir()
-  else:
-    dest_local = dest
-
   try:
-    stow(getLinkableFiles(appPath=app, dest=dest_local), simulate=simulate, verbose=verbose, force=force)
+    stow(getLinkableFiles(appPath=app, dest=dest), simulate=simulate, verbose=verbose, force=force)
   except ValueError:
     echo "Error happened: " & getCurrentExceptionMsg()
 

--- a/src/nistow.nim
+++ b/src/nistow.nim
@@ -84,8 +84,7 @@ when isMainModule:
   # (like --app in this case), if the mandatoryOverride switch --version is present.
   dispatchGen(nistow,
               mandatoryOverride = @["version"])
-  # If the user has run the binary without any switches, pass the --help switch
-  # automatically to dispatch_nistow.
-  # Else, collect the passed switches using commandLineParams() and pass those to
-  # dispatch_nistow.
-  quit(dispatch_nistow(if paramCount() > 0: commandLineParams() else: @[ "--help" ]))
+  if paramCount()==0:
+    quit(dispatch_nistow(@["--help"]))
+  else:
+    quit(dispatch_nistow(commandLineParams()))


### PR DESCRIPTION
Use the cligen package to parse the commandline arguments. It does the job of autogenerating the help, auto-detecting long/short form switches, auto-generating error if the mandatory switch app is present, etc.

Printed help now looks like this:

```
Usage:
  nistow [required&optional-params]
Stow 0.1.0 (Manage your dotfiles easily)
  Options(opt-arg sep :|=|spc):
  -h, --help                              print this help message
  -v, --version   bool    false           set version
  -s, --simulate  bool    false           set simulate
  --verbose       bool    false           set verbose
  -f, --force     bool    false           set force
  -a=, --app=     string  REQUIRED        set app
  -d=, --dest=    string  "/home/kmodi/"  set dest
```